### PR TITLE
feat: support task delete

### DIFF
--- a/internal/handler/graphql/generated/generated.go
+++ b/internal/handler/graphql/generated/generated.go
@@ -67,6 +67,7 @@ type ComplexityRoot struct {
 
 	Mutation struct {
 		CreateTask func(childComplexity int, input models.CreateTask) int
+		DeleteTask func(childComplexity int, id int64) int
 		EditTask   func(childComplexity int, id int64, input models.EditTask) int
 	}
 
@@ -129,6 +130,7 @@ type JobResolver interface {
 type MutationResolver interface {
 	CreateTask(ctx context.Context, input models.CreateTask) (*models1.Task, error)
 	EditTask(ctx context.Context, id int64, input models.EditTask) (*models1.Task, error)
+	DeleteTask(ctx context.Context, id int64) (*bool, error)
 }
 type QueryResolver interface {
 	Task(ctx context.Context, id int64) (*models1.Task, error)
@@ -269,6 +271,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateTask(childComplexity, args["input"].(models.CreateTask)), true
+
+	case "Mutation.deleteTask":
+		if e.complexity.Mutation.DeleteTask == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteTask_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteTask(childComplexity, args["id"].(int64)), true
 
 	case "Mutation.editTask":
 		if e.complexity.Mutation.EditTask == nil {
@@ -705,6 +719,10 @@ type Mutation {
     Edit a task
     """
     editTask(id: ID!, input: EditTask!): Task
+    """
+    Delete a task
+    """
+    deleteTask(id: ID!): Boolean
 }
 `, BuiltIn: false},
 	{Name: "../schema/task/input.graphql", Input: `"""
@@ -968,6 +986,21 @@ func (ec *executionContext) field_Mutation_createTask_args(ctx context.Context, 
 		}
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteTask_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int64
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2int64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -1860,6 +1893,58 @@ func (ec *executionContext) fieldContext_Mutation_editTask(ctx context.Context, 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_editTask_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteTask(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteTask(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteTask(rctx, fc.Args["id"].(int64))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteTask(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteTask_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -5803,6 +5888,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_editTask(ctx, field)
+			})
+
+		case "deleteTask":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteTask(ctx, field)
 			})
 
 		default:

--- a/internal/handler/graphql/resolvers/root.resolvers.go
+++ b/internal/handler/graphql/resolvers/root.resolvers.go
@@ -124,6 +124,27 @@ func (r *mutationResolver) EditTask(ctx context.Context, id int64, input models1
 	return &task, nil
 }
 
+// DeleteTask is the resolver for the deleteTask field.
+func (r *mutationResolver) DeleteTask(ctx context.Context, id int64) (*bool, error) {
+	var task models.Task
+	result := database.GetDatabase().Where("id = ?", id).Find(&task)
+	if err := result.Error; err != nil {
+		return nil, err
+	}
+	if result.RowsAffected <= 0 {
+		return nil, errors.Errorf("task does not exist: id %d", id)
+	}
+
+	result = database.GetDatabase().Delete(&task)
+	if err := result.Error; err != nil {
+		return nil, errors.Wrap(err, "failed to delete task")
+	}
+	if result.RowsAffected < 1 {
+		return nil, errors.New("failed to delete task: data is not deleted")
+	}
+	return gog.Ptr(true), nil
+}
+
 // Task is the resolver for the task field.
 func (r *queryResolver) Task(ctx context.Context, id int64) (*models.Task, error) {
 	var task models.Task

--- a/internal/handler/graphql/schema/root.graphql
+++ b/internal/handler/graphql/schema/root.graphql
@@ -26,4 +26,8 @@ type Mutation {
     Edit a task
     """
     editTask(id: ID!, input: EditTask!): Task
+    """
+    Delete a task
+    """
+    deleteTask(id: ID!): Boolean
 }


### PR DESCRIPTION
### Description

Based on GraphQL Mutation to implement the Task deletion API, it does not currently support association deletion of rules.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible